### PR TITLE
protected gdal imports to work with gdal from conda/pip

### DIFF
--- a/parflow/subset/mask.py
+++ b/parflow/subset/mask.py
@@ -18,7 +18,7 @@ class SubsetMask:
                f"no_data_value:{self.no_data_value!r}, inner_mask_edges:{self.inner_mask_edges!r}, " \
                f"bbox_edges:{self.bbox_edges!r}"
 
-    def __init__(self, tif_file, bbox_val=0):
+    def __init__(self, tif_file, bbox_val=0, mask_value=1):
         """Create a new instance of SubsetMask
 
         Parameters
@@ -27,12 +27,17 @@ class SubsetMask:
             path to tiff file containing mask
         bbox_val : int, optional
             integer value specifying the data value for bounding box cells
+        mask_value : int, optional
+            integer value specifying the data value in the tiff file to consider as the masking value
         Returns
         -------
         SubsetMask
         """
         self.mask_tif = read_geotiff(tif_file)
         self.mask_array = read_file(tif_file)
+        self.mask_array = np.where(self.mask_array == mask_value, 1, 0)
+        if not np.any(self.mask_array):
+            raise Exception('Unable to create mask without a single masking location')
         self.bbox_val = bbox_val
         self.inner_mask = self._find_inner_object()  # tight crop
         self.bbox_mask = self._find_bbox()  # bbox crop

--- a/parflow/subset/rasterizer.py
+++ b/parflow/subset/rasterizer.py
@@ -1,6 +1,14 @@
 """Classes for converting inputs to gridded masks"""
-import gdal
-import ogr
+try:
+    from osgeo import gdal
+except ImportError:
+    import gdal
+
+try:
+    from osgeo import ogr
+except ImportError:
+    import ogr
+
 import os
 import logging
 from parflow.subset import TIF_NO_DATA_VALUE_OUT as NO_DATA

--- a/parflow/subset/utils/huc2shape.py
+++ b/parflow/subset/utils/huc2shape.py
@@ -2,8 +2,17 @@ import requests
 import itertools
 import urllib.parse
 import xml.etree.ElementTree as ET
-from osgeo import ogr
-from osgeo import osr
+
+try:
+    from osgeo import ogr
+except ImportError:
+    import ogr
+
+try:
+    from osgeo import osr
+except ImportError:
+    import osr
+
 from shapely import geometry
 '''
 date: 04.17.2020

--- a/parflow/subset/utils/io.py
+++ b/parflow/subset/utils/io.py
@@ -6,7 +6,10 @@ import logging
 from pathlib import Path
 import pandas as pd
 import numpy as np
-import gdal
+try:
+    from osgeo import gdal
+except ImportError:
+    import gdal
 from parflow.subset import TIF_NO_DATA_VALUE_OUT as NO_DATA
 from parflowio.pyParflowio import PFData
 from parflow.subset.bbox import BBox

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="parflow_subsetter",
-    version="0.99.7",
+    version="0.99.8",
     author="HydroFrame Team",
     author_email="parflow@parflow.org",
     description="A set of tools for clipping ParFlow model inputs and outputs",


### PR DESCRIPTION
Instead of using `gdal` from `conda`, we're using `gdal` 3.2.1 installed from gdal sources (using the `--with-python` autoconf flag) in a virtualenv on Verde @ Princeton. This enables us to have a single install for both python/non-python use. It looks like in this version, the package namespace used is simply `osgeo`, also mentioned in:

https://pypi.org/project/GDAL/

The code at one place was also using `osgeo` directly, so I'm not sure if the older imports need to be supported. But this change works in our case (and some simple subsetting scripts seem to work great!)

