### PR TITLE
Ability to subset conus with a pre-generated geotiff

### DIFF
--- a/parflow/subset/mask.py
+++ b/parflow/subset/mask.py
@@ -18,7 +18,7 @@ class SubsetMask:
                f"no_data_value:{self.no_data_value!r}, inner_mask_edges:{self.inner_mask_edges!r}, " \
                f"bbox_edges:{self.bbox_edges!r}"
 
-    def __init__(self, tif_file, bbox_val=0):
+    def __init__(self, tif_file, bbox_val=0, mask_value=1):
         """Create a new instance of SubsetMask
 
         Parameters
@@ -27,12 +27,17 @@ class SubsetMask:
             path to tiff file containing mask
         bbox_val : int, optional
             integer value specifying the data value for bounding box cells
+        mask_value : int, optional
+            integer value specifying the data value in the tiff file to consider as the masking value
         Returns
         -------
         SubsetMask
         """
         self.mask_tif = read_geotiff(tif_file)
         self.mask_array = read_file(tif_file)
+        self.mask_array = np.where(self.mask_array == mask_value, 1, 0)
+        if not np.any(self.mask_array):
+            raise Exception('Unable to create mask without a single masking location')
         self.bbox_val = bbox_val
         self.inner_mask = self._find_inner_object()  # tight crop
         self.bbox_mask = self._find_bbox()  # bbox crop

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="parflow_subsetter",
-    version="0.99.7",
+    version="0.99.8",
     author="HydroFrame Team",
     author_email="parflow@parflow.org",
     description="A set of tools for clipping ParFlow model inputs and outputs",


### PR DESCRIPTION
We have a use case in which we need to subset CONUS data with a pregenerated geotiff file. These `.tif` files have several unique non-zero values representing basin IDs (closely related to HUC IDs I think).

The couple of changes here will allow us to do the subsetting based on a given value of the basin ID. I've gone through the execution of this modified code for both CONUS 1 and CONUS 2 data and the old behavior is preserved, while doing the right thing for the new use case.

Some clarifications on the code changes in advance:

- The `if not np.any(self.mask_array):` check in `SubsetMask` is not directly related to the changes, but I observed that if all these values are `False`, the code throws an error much further down the processing (both in the old and new versions), so I added the check so we can fail early on.
- I was a bit hesitant in adding new arguments towards the front for the `subset_conus` function, but all use-cases I've seen of this function use kwargs, so I went with what I thought was the natural place for these new arguments.

Happy to discuss more if needed!