### PR TITLE
Clip CLM input (vegm files)

### DIFF
--- a/parflow/subset/tools/bulk_clipper.py
+++ b/parflow/subset/tools/bulk_clipper.py
@@ -154,7 +154,7 @@ def locate_tifs(file_list) -> list:
 
 
 def clip_inputs(clipper, input_list, out_dir='.', pfb_outs=1, tif_outs=0, no_data=NO_DATA, output_suffix='_clip',
-                n_threads=1) -> None:
+                n_workers=1) -> None:
     """clip a list of files using a clipper object
 
     Parameters
@@ -173,8 +173,8 @@ def clip_inputs(clipper, input_list, out_dir='.', pfb_outs=1, tif_outs=0, no_dat
         no_data value for tifs (optional) (Default value = NO_DATA)
     output_suffix : str, optional
         filename suffix to add to all output pfb/tif files
-    n_threads: int, optional
-        No. of parallel threads to launch for clipping files (Default value = 1)
+    n_workers: int, optional
+        No. of parallel workers to launch for clipping files (Default value = 1)
     Returns
     -------
     None
@@ -194,7 +194,7 @@ def clip_inputs(clipper, input_list, out_dir='.', pfb_outs=1, tif_outs=0, no_dat
                                                  return_arr, new_geom, ref_proj, no_data=no_data)
         del return_arr
 
-    with ThreadPoolExecutor(max_workers=min(n_threads, len(input_list))) as executor:
+    with ThreadPoolExecutor(max_workers=min(n_workers, len(input_list))) as executor:
         to_do = []
         for data_file in input_list:
             future = executor.submit(_clip, data_file)

--- a/parflow/subset/tools/bulk_clipper.py
+++ b/parflow/subset/tools/bulk_clipper.py
@@ -152,7 +152,8 @@ def locate_tifs(file_list) -> list:
     return list([s for s in file_list if '.tif' in s.lower()])
 
 
-def clip_inputs(clipper, input_list, out_dir='.', pfb_outs=1, tif_outs=0, no_data=NO_DATA) -> None:
+def clip_inputs(clipper, input_list, out_dir='.', pfb_outs=1, tif_outs=0, no_data=NO_DATA, output_suffix='_clip')\
+        -> None:
     """clip a list of files using a clipper object
 
     Parameters
@@ -169,7 +170,8 @@ def clip_inputs(clipper, input_list, out_dir='.', pfb_outs=1, tif_outs=0, no_dat
         write tif files as outputs (optional) (Default value = 0)
     no_data : int, optional
         no_data value for tifs (optional) (Default value = NO_DATA)
-
+    output_suffix : str, optional
+        filename suffix to add to all output pfb/tif files
     Returns
     -------
     None
@@ -184,9 +186,9 @@ def clip_inputs(clipper, input_list, out_dir='.', pfb_outs=1, tif_outs=0, no_dat
         filename = Path(data_file).stem
         return_arr, new_geom, _, _ = clipper.subset(file_io_tools.read_file(data_file))
         if pfb_outs:
-            file_io_tools.write_pfb(return_arr, os.path.join(out_dir, f'{filename}_clip.pfb'))
+            file_io_tools.write_pfb(return_arr, os.path.join(out_dir, f'{filename}{output_suffix}.pfb'))
         if tif_outs and new_geom is not None and ref_proj is not None:
-            file_io_tools.write_array_to_geotiff(os.path.join(out_dir, f'{filename}_clip.tif'),
+            file_io_tools.write_array_to_geotiff(os.path.join(out_dir, f'{filename}{output_suffix}.tif'),
                                                  return_arr, new_geom, ref_proj, no_data=no_data)
         del return_arr
 


### PR DESCRIPTION
Added a new method to the `CLMClipper` class to directly clip `drv_vegm.dat` files instead of only working with separate land-cover and latitude-longitude files (which is still supported). This is the immediate use-case we're seeing in subsetting CONUS1 data on the Verde cluster.

Also added an optional parameter to customize the output subsetted pfb/tiff files, so we're not forced to use the `_clip` suffix. Usage of this suffix prevents its use in subsetting forcing data effectively, where `parflow` expects these files to have a per-determined file pattern (like `NLDAS.Press.001633_to_001655.pfb`)