### PR TITLE
Fix for unit test breakage

### DIFF
--- a/parflow/subset/mask.py
+++ b/parflow/subset/mask.py
@@ -39,9 +39,9 @@ class SubsetMask:
         try:
             iter(mask_value)
         except TypeError:
-            self.mask_array = np.where(self.mask_array == mask_value, 1, 0)
+            self.mask_array = np.where(self.mask_array == mask_value, 1, self.mask_array)
         else:
-            self.mask_array = np.where(np.isin(self.mask_array, mask_value), 1, 0)
+            self.mask_array = np.where(np.isin(self.mask_array, mask_value), 1, self.mask_array)
             
         if not np.any(self.mask_array):
             raise Exception('Unable to create mask without a single masking location')

--- a/tests/subset_mask_tests.py
+++ b/tests/subset_mask_tests.py
@@ -28,7 +28,7 @@ class SubsetMaskClassTests(unittest.TestCase):
         my_mask.write_mask_to_tif("WBDHU8_conus1_mask_padded.tif")
 
     def test_all_zeroes_ones_mask(self):
-        my_mask = SubsetMask(test_all_zeros_and_ones_mask,mask_value=0)
+        my_mask = SubsetMask(test_all_zeros_and_ones_mask)
         self.assertSequenceEqual((1752, 2222, 3672, 4078), my_mask.inner_mask_edges)
         self.assertSequenceEqual((1752, 2222, 3672, 4078), my_mask.bbox_edges)
         self.assertSequenceEqual((471, 407), my_mask.bbox_shape)
@@ -40,7 +40,7 @@ class SubsetMaskClassTests(unittest.TestCase):
         self.assertSequenceEqual((471, 407), my_mask.inner_mask_shape)
 
     def test_get_padding_from_mask(self):
-        my_mask = SubsetMask(test_all_zeros_and_ones_mask,mask_value=0)
+        my_mask = SubsetMask(test_all_zeros_and_ones_mask)
         self.assertSequenceEqual((1752, 2222, 3672, 4078), my_mask.inner_mask_edges)
         self.assertSequenceEqual((1752, 2222, 3672, 4078), my_mask.bbox_edges)
         self.assertSequenceEqual((471, 407), my_mask.bbox_shape)


### PR DESCRIPTION
The reason the unit tests were failing is because my naive assumption that I can simply check for 1/0 values in the mask to decide what to mask:
```
self.mask_array = np.where(self.mask_array == mask_value, 1, 0)
```
holds in all cases where we actually _use_ this library, but not in the more general case handled by the library (i.e. the cases that are covered by the unit tests). In these unit tests, the `.tiff` files used for the mask have 3 values - a sentinel value implying 'no data', and then 0/1 values for the actual mask. For example, the following is an example of a typical mask that the `parflow.subset` library expects to encounter:

```
-999 -999 -999 -999 -999
-999    0    0    0 -999
-999    0    1    0 -999
-999    0    0    0 -999
-999 -999 -999 -999 -999
```

Here a 0/1 mask of size 3x3 is embedded inside a larger 5x5 mask of values where `-999` indicates data we can effectively ignore, and 0/1 give us the locations to ignore/consider respectively.

So the way I _should_ have written my code to create a 0/1 mask should have been to convert to 1 any values that I care about, but leave others as-is (not force them to become 0):
```
self.mask_array = np.where(self.mask_array == mask_value, 1, self.mask_array)
```

This is precisely what this PR does.

The recent change made to `subset_mask_tests.py`, changing:
```
SubsetMask(test_all_zeros_and_ones_mask)
```
to
```
SubsetMask(test_all_zeros_and_ones_mask,mask_value=0)
```
is not needed, and _is in fact incorrect_ (since it arbitrarily changes the default mask_value). I suspect this was exploratory code that made its way to `master`. This has been reverted now.

With these changes, all tests pass on Verde.