### PR TITLE
Correct fix for unit tests

### DIFF
--- a/parflow/subset/mask.py
+++ b/parflow/subset/mask.py
@@ -6,6 +6,7 @@ import numpy as np
 import numpy.ma as ma
 from parflow.subset.utils.io import read_geotiff, write_array_to_geotiff, write_bbox, read_file, write_pfb
 from parflow.subset.bbox import BBox
+from parflow.subset import TIF_NO_DATA_VALUE_OUT as NO_DATA
 
 
 class SubsetMask:
@@ -18,7 +19,7 @@ class SubsetMask:
                f"no_data_value:{self.no_data_value!r}, inner_mask_edges:{self.inner_mask_edges!r}, " \
                f"bbox_edges:{self.bbox_edges!r}"
 
-    def __init__(self, tif_file, bbox_val=0, mask_value=1):
+    def __init__(self, tif_file, bbox_val=0, mask_value=None):
         """Create a new instance of SubsetMask
 
         Parameters
@@ -29,6 +30,7 @@ class SubsetMask:
             integer value specifying the data value for bounding box cells
         mask_value : int or iterable of ints, optional
             integer value(s) specifying the data value in the tiff file to consider as the masking value
+            If None, then all +ve data values are considered as the masking value
         Returns
         -------
         SubsetMask
@@ -36,12 +38,13 @@ class SubsetMask:
         self.mask_tif = read_geotiff(tif_file)
         self.mask_array = read_file(tif_file)
 
-        try:
-            iter(mask_value)
-        except TypeError:
-            self.mask_array = np.where(self.mask_array == mask_value, 1, self.mask_array)
-        else:
-            self.mask_array = np.where(np.isin(self.mask_array, mask_value), 1, self.mask_array)
+        if mask_value is not None:
+            try:
+                iter(mask_value)
+            except TypeError:
+                self.mask_array = np.where(self.mask_array == mask_value, 1, 0)
+            else:
+                self.mask_array = np.where(np.isin(self.mask_array, mask_value), 1, 0)
             
         if not np.any(self.mask_array):
             raise Exception('Unable to create mask without a single masking location')

--- a/parflow/subset/mask.py
+++ b/parflow/subset/mask.py
@@ -6,7 +6,6 @@ import numpy as np
 import numpy.ma as ma
 from parflow.subset.utils.io import read_geotiff, write_array_to_geotiff, write_bbox, read_file, write_pfb
 from parflow.subset.bbox import BBox
-from parflow.subset import TIF_NO_DATA_VALUE_OUT as NO_DATA
 
 
 class SubsetMask:

--- a/parflow/subset/tools/subset_conus.py
+++ b/parflow/subset/tools/subset_conus.py
@@ -109,7 +109,7 @@ def parse_args(args):
     return parser.parse_args(args)
 
 
-def subset_conus(input_path=None, shapefile=None, subset_tif=None, mask_value=1, conus_version=1, conus_files='.',
+def subset_conus(input_path=None, shapefile=None, subset_tif=None, mask_value=None, conus_version=1, conus_files='.',
                  out_dir='.', out_name=None, clip_clm=False, run_script=False, padding=(0, 0, 0, 0),
                  attribute_name='OBJECTID', attribute_ids=None, write_tifs=False, manifest_file=conus_manifest):
     """subset a conus domain inputs for running a regional model
@@ -124,6 +124,7 @@ def subset_conus(input_path=None, shapefile=None, subset_tif=None, mask_value=1,
         path to tiff file containing mask. Required if shapefile is not provided.
     mask_value : int, optional
         integer value specifying the data value in the tiff file to consider as the masking value.
+        If None, all +ve values are considered as the masking value
         Only applicable if subset_tif is provided.
     conus_version : int, optional
         version of the CONUS domain to use (1 or 2) (Default value = 1)


### PR DESCRIPTION
Take 2 on the fixing the code to satisfy the unit tests.

Of course we want to zero out values that don't match our desired mask values, but only in the case when we were explicit about the `mask_value` to begin with. When `mask_value=None` (the default case now), we don't do any processing, which should keep the unit tests happy, while not causing the domain to blow up in size because it finds +ve values outside the desired domain (which it never clips out).